### PR TITLE
Add automated testing using Travis CI and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: python 
 cache: pip
 install:
   # - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+cache: pip
+install:
+  # - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  email: false


### PR DESCRIPTION
To enable free automated testing of all code changes, you would need to:
1. go to https://travis-ci.com/cvpe
2. log in with GitHub credentials
3. select the __free plan__, and
4. flip the repository switch __on__.

When that is done, Travis CI will lint your Python code with http://flake8.pycqa.org