### PR TITLE
Undefined name: import os

### DIFF
--- a/VersionInStatusBar.py
+++ b/VersionInStatusBar.py
@@ -1,5 +1,6 @@
 import ui
 import objc_util
+import os
 import sys
 
 def VersionInStatusBar(version=False):	


### PR DESCRIPTION
__os__ is used on lines 9 and 10 but it is never imported.  Discovered via #18