### PR TITLE
Travis CI: add flake8 E722 do not use bare 'except'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  - flake8 . --count --select=E722,E9,F63,F72,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:


### PR DESCRIPTION
https://pep8.org/#programming-recommendations
https://realpython.com/the-most-diabolical-python-antipattern

$ __flake8 . --count --select=E722,E9,F63,F72,F82 --show-source --statistics__
```
./MyPickDocument.py:35:1: E722 do not use bare 'except'
except:
^
./SaveInFiles.py:25:1: E722 do not use bare 'except'
except:
^
./contacts on map.py:131:1: E722 do not use bare 'except'
except:
^
3     E722 do not use bare 'except'
3
```